### PR TITLE
Cleanup and update for React 0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "homepage": "https://github.com/nkbt/react-component-template",
   "peerDependencies": {
-    "react": "^0.13 || ^0.14"
+    "react": "^0.14.0"
   },
   "devDependencies": {
     "babel": "^5.8.23",
@@ -76,6 +76,7 @@
     "parallelshell": "^2.0.0",
     "phantomjs": "^1.9.18",
     "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.4.3",
     "tap-xunit": "^1.2.1",

--- a/src/example/Example.js
+++ b/src/example/Example.js
@@ -1,5 +1,9 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import App from './App';
 
+const appRoot = document.createElement('div');
 
-React.render(<App />, document.body);
+appRoot.id = 'app';
+document.body.appendChild(appRoot);
+ReactDOM.render(<App />, appRoot);


### PR DESCRIPTION
- Exclusively depend on ^0.14.0 of react
- Use react-dom's render in example
- In example don't render directly into document.body, this causes a React warning
