### PR TITLE
Remove Hot Reload

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -7,9 +7,6 @@
     "transform-object-rest-spread"
   ],
   "env": {
-    "development": {
-      "presets": ["react-hmre"]
-    },
     "test": {
       "plugins": [
         [

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "babel-plugin-webpack-loaders": "0.4.0",
     "babel-preset-es2015": "6.6.0",
     "babel-preset-react": "6.5.0",
-    "babel-preset-react-hmre": "1.1.1",
     "codecov.io": "0.1.6",
     "cross-env": "1.0.7",
     "css-loader": "0.23.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,14 +37,12 @@ const development = {
 
   entry: [
     './src/example/Example.js',
-    'webpack-dev-server/client?http://localhost:8080',
-    'webpack/hot/only-dev-server'
+    'webpack-dev-server/client?http://localhost:8080'
   ],
   output: {filename: 'bundle.js', path: path.resolve('example')},
   plugins: [
     new HtmlWebpackPlugin(),
-    definePlugin,
-    new webpack.HotModuleReplacementPlugin()
+    definePlugin
   ],
   module: {
     loaders,
@@ -55,7 +53,6 @@ const development = {
   resolve,
   stats,
   devServer: {
-    hot: true,
     historyApiFallback: true,
     stats: {
       // Do not show list of hundreds of files included in a bundle


### PR DESCRIPTION
Since it is not working with functional components and does not work reliably in general (see https://medium.com/@dan_abramov/hot-reloading-in-react-1140438583bf#.bglf6wyop).

Also it is not that necessary for lib development to be honest.
